### PR TITLE
Fix frequent crashes with index out of bounds exception

### DIFF
--- a/src/main/kotlin/com/alchitry/labs2/ui/code_editor/styles/CodeStyler.kt
+++ b/src/main/kotlin/com/alchitry/labs2/ui/code_editor/styles/CodeStyler.kt
@@ -28,9 +28,11 @@ class CodeStyler(
             val end = token.range.endInclusive.coerceInRange(lines)
 
             if (token.isSingleLine) {
-                styles[start.line].add(
-                    LineStyle(start.offset, end.offset, token.style)
-                )
+                if (styles.size > 0) {
+                    styles[start.line].add(
+                        LineStyle(start.offset, end.offset, token.style)
+                    )
+                }
                 return@forEach
             }
 


### PR DESCRIPTION
![image](https://github.com/alchitry/Alchitry-Labs-V2/assets/16506822/d6bb94a9-967a-4646-8813-33d6bb64a278)

Error message above frequently appears when opening project or when creating a new Lucid module. Added check to prevent indexing into zero length `styles`.